### PR TITLE
Corregido error de choque de opciones para el paquete babel

### DIFF
--- a/Constructor/configuracion/upiitatesis.sty
+++ b/Constructor/configuracion/upiitatesis.sty
@@ -44,7 +44,6 @@ freely copied and distributed.}
 \usepackage{graphicx}
 \usepackage{lettrine}
 \usepackage[pdftex,colorlinks=true,linkcolor=black]{hyperref}
-\usepackage[spanish, english]{babel}
 \usepackage[latin1]{inputenc}
 \usepackage[Sonny]{Constructor/configuracion/fncychap}
 \usepackage{fancyhdr}


### PR DESCRIPTION
Existía un error que no dejaba mostrar el documento al ser compilado

Para corregirlo me basé en esta [pregunta](https://tex.stackexchange.com/questions/135060/getting-an-option-clash-with-babel-english-greek)